### PR TITLE
Fixes for safe_z enabled homing

### DIFF
--- a/Config/Sensorless-Homing.cfg
+++ b/Config/Sensorless-Homing.cfg
@@ -267,10 +267,10 @@ gcode:
       {% endif %}                                                                                   #
     {% endif %}                                                                                     #
 
-    {% if safe_z == True and home_all or 'Z' in params %}                                           # If safe_z is true and home_all or 'Z' is in params,
+    {% if safe_z == True and (home_all or 'Z' in params) %}                                         # If safe_z is true and home_all or 'Z' is in params,
         G0 X{safe_x} Y{safe_y} F{travel_speed}                                                      # Move to the defined safe XY location
     {% endif %}                                                                                     #
-    
+
     {% if home_all or 'Z' in params %}                                                              #
         G28 Z                                                                                       # Home the Z axis
         G0 Z{z_hop_distance} F{z_hop_speed}                                                         # Move Z to z_hop_distance

--- a/Config/Sensorless-Homing.cfg
+++ b/Config/Sensorless-Homing.cfg
@@ -223,6 +223,10 @@ gcode:
         {% set probe_y_offset = 0 | float %}                                                        # If Z if not homed with a probe, set offsets to 0 (do not apply an offset)
     {% endif %}                                                                                     #
 
+    {% if safe_x == -128 %}                                                                         #
+        {% set safe_x = (printer.configfile.settings.stepper_x.position_max) /2 %}                  # If safe_x is '-128', set safe_x to the center of the X axis
+    {% endif %}                                                                                     #
+
     {% if probe_x_offset < 0 %}                                                                     #
         {% set safe_x = safe_x + probe_x_offset %}                                                  #
     {% elif probe_x_offset > 0 %}                                                                   # Depending on if probe_x_offset is a positive or negative value, adjust safe_x
@@ -237,30 +241,6 @@ gcode:
         {% set safe_y = safe_y + probe_y_offset %}                                                  #
     {% elif probe_y_offset > 0 %}                                                                   # Depending on if probe_y_offset is a positive or negative value, adjust safe_y
         {% set safe_y = safe_y - probe_y_offset %}                                                  # If the machine does not home Z with a probe, an offset is not applied.
-    {% endif %}                                                                                     #
-
-    {% if safe_z == True %}                                                                         # Check if safe_z is enabled
-
-        {% if safe_x == -128 %}                                                                     #
-            {% set safe_x = (printer.configfile.settings.stepper_x.position_max) /2 %}              # If safe_x is '-128', set safe_x to the center of the X axis
-        {% endif %}                                                                                 # otherwise, use configured value
-
-        {% if safe_y == -128 %}                                                                     # 
-            {% set safe_y = (printer.configfile.settings.stepper_y.position_max) /2 %}              # If safe_y is '-128', set safe_y to the center of the Y axis
-        {% endif %}                                                                                 # otherwise, use configured value
-
-        {% if probe_x_offset < 0 %}                                                                 # Depending on if probe_x_offset is a positive or negative value, adjust safe_x
-            {% set safe_x = safe_x + probe_x_offset %}                                              # Positive X offset = Probe is to the right of the nozzle
-        {% elif probe_x_offset > 0 %}                                                               # Negative X offset = Probe is to the left of the nozzle
-            {% set safe_x = safe_x - probe_x_offset %}                                              # If the machine does not home Z with a probe, an offset is not applied.
-        {% endif %}                                                                                 #
-
-        {% if probe_y_offset < 0 %}                                                                 # Depending on if probe_y_offset is a positive or negative value, adjust safe_y
-            {% set safe_y = safe_y + probe_y_offset %}                                              # Positive Y offset = Probe is behind the nozzle
-        {% elif probe_y_offset > 0 %}                                                               # Negative Y offset = Probe is in front of the nozzle
-            {% set safe_y = safe_y - probe_y_offset %}                                              # If the machine does not home Z with a probe, an offset is not applied.
-        {% endif %}                                                                                 #
-
     {% endif %}                                                                                     #
 
     {% if z_hop_distance > 0 %}                                                                     # Check if z_hop_distance is greater than zero


### PR DESCRIPTION
- Fix safe_x position calculation
  With safe_z == True the previous implementation would apply the
probe offsets to the sentinel value of -128, which would make
later checks for -128 fail, skipping calculating the correct position.

  Homing could fail with "Move out of range" errors.

  Moving the calculation before the application of probe offsets
also makes the whole second safe_z block redundant.

- Fix safe_z move conditional
  Operator precedence in python is AND before OR. For this conditional
it means that the check was done like this:

  1. safe_z == True AND home_all
  2. OR Z in params

  This resulted in the Z move being applied on G28 Z, even when safe_z was disabled

  This is fixed by forcing the home_all or Z in params conditional to be evaluated first.