### PR TITLE
Add cartographer

### DIFF
--- a/Config/Sensorless-Homing.cfg
+++ b/Config/Sensorless-Homing.cfg
@@ -213,7 +213,7 @@ gcode:
         {% set probe_name = printer.configfile.settings.dockable_probe %}                           # If [dockable_probe] is found in config, set 'probe_name' as [dockable_probe] config string
     {% elif printer.configfile.settings.bltouch is defined %}                                       #
         {% set probe_name = printer.configfile.settings.bltouch %}                                  # If [bltouch] is found in config, set 'probe_name' as [bltouch] config string
-        {% elif printer.configfile.settings.cartographer is defined %}                                  # Check if a third-party [probe] definiton is used
+    {% elif printer.configfile.settings.cartographer is defined %}                                  # Check if a third-party [probe] definiton is used
         {% set probe_name = printer.configfile.settings.cartographer %}                             # If [cartographer] is found in config, set 'probe_name' as [cartographer] config string
     {% endif %}                                                                                     #
 

--- a/Config/Sensorless-Homing.cfg
+++ b/Config/Sensorless-Homing.cfg
@@ -213,6 +213,8 @@ gcode:
         {% set probe_name = printer.configfile.settings.dockable_probe %}                           # If [dockable_probe] is found in config, set 'probe_name' as [dockable_probe] config string
     {% elif printer.configfile.settings.bltouch is defined %}                                       #
         {% set probe_name = printer.configfile.settings.bltouch %}                                  # If [bltouch] is found in config, set 'probe_name' as [bltouch] config string
+        {% elif printer.configfile.settings.cartographer is defined %}                                  # Check if a third-party [probe] definiton is used
+        {% set probe_name = printer.configfile.settings.cartographer %}                             # If [cartographer] is found in config, set 'probe_name' as [cartographer] config string
     {% endif %}                                                                                     #
 
     {% if 'probe' in printer.configfile.settings.stepper_z.endstop_pin %}                           # Check if Z is configured to home with a probe and pull config values for


### PR DESCRIPTION
Came across this while I was setting up sensorless homing for the first time. 

Minnor addition to create support for the cartographer probe

Unrelated... enabling save_z by default might be a good idea.  Nearly had a nasty crash as a result.